### PR TITLE
Fix macOS incorrect working directory

### DIFF
--- a/src/main/java/zenpad/launcher/ZenPad.java
+++ b/src/main/java/zenpad/launcher/ZenPad.java
@@ -13,7 +13,7 @@ import zenpad.utils.LafManager;
  * @see AppFrame
  */
 
-public class MainApp {
+public class ZenPad {
     public static void main(String[] args) {
         SwingUtilities.invokeLater(() -> {
             LafManager.applyLightLaf();

--- a/src/main/java/zenpad/runners/TerminalLauncher.java
+++ b/src/main/java/zenpad/runners/TerminalLauncher.java
@@ -13,8 +13,16 @@ public class TerminalLauncher {
         if (os.contains("win")) {
             pb = new ProcessBuilder("cmd", "/c", "start", "cmd", "/k", command);
         } else if (os.contains("mac")) {
-            pb = new ProcessBuilder("osascript", "-e",
-                "tell application \"Terminal\" to do script \"" + command.replace("\"", "\\\"") + "\"");
+            String macCommand = (
+                "cd '" + workingDir.getAbsolutePath() +
+                "' && " + command + "; exec bash"
+            );
+
+            pb = new ProcessBuilder(
+                "osascript", "-e",
+                "tell application \"Terminal\" to do script \"" +
+                macCommand.replace("\"", "\\\"") + "\""
+            );
         } else {
             String terminal = detectLinuxTerminal();
             pb = new ProcessBuilder(terminal, "-e", "bash -c '" + command + "; exec bash'");


### PR DESCRIPTION
As observed, running samples on macOS did not open a terminal in the expected working directory. This was a key learning experience regarding the typical behaviors of `osascript`.

To resolve this, the `test4` branch has been updated with a commit that introduces a `macCommand` string. This string will ensure the terminal changes to the specified working directory within the source code. Additionally, the main class has been renamed to correctly display the application's name in macOS.